### PR TITLE
feat: 保存済みスポットから予約ページへの遷移機能を追加とUI改善

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,119 @@
+# Claude Code Configuration
+
+This file contains configuration and context for Claude Code to better understand and work with this project.
+
+## Project Overview
+Tour application project - HTML/CSS/JavaScript based web application
+
+---
+
+## AIツールの主な役割と支援範囲
+
+AI支援ツールは以下のカテゴリの支援を前提とします：
+
+### 1. ドメインモデル設計
+
+* 型安全なモデルの定義補助
+* データ永続化層との整合性考慮
+* 各種データ変換処理の実装補助
+
+### 2. データ同期・永続化
+
+* 外部APIやデータベースとの同期ロジック支援
+* ローカルキャッシュ管理の補助
+* 整合性を重視したデータ操作の実装補助
+
+### 3. 状態管理
+
+* JavaScript状態管理の構成改善
+* UIと状態管理層の最適化支援
+* 複雑な状態の適切な分離と整理
+
+### 4. UIロジック
+
+* UI層での状態管理との連携最適化
+* UIコンポーネント・画面遷移ロジックの支援
+
+---
+
+## AIツールの操作制限（コマンド制限）
+
+> AIツールが使用できるのは**Makefileや指定されたスクリプト経由の安全な操作のみ**です。
+> 明示的に許可されていない任意コマンドやスクリプトを**実行することはできません**。
+
+---
+
+## AIツールが触れてよいファイル種別
+
+AIが読み書き支援を行うファイル範囲：
+
+| 分類      | 対象パス例                           |
+| ------- | ------------------------------- |
+| モデル定義   | `src/models/**/*.js`            |
+| サービス層   | `src/services/**/*.js`          |
+| ユーティリティ | `src/utils/**/*.js`             |
+| コンポーネント | `src/components/**/*.js`        |
+| ページスクリプト| `scripts/**/*.js`               |
+| HTMLページ | `pages/**/*.html`               |
+| スタイル    | `styles/**/*.css`               |
+| データファイル | `data/**/*.json`                |
+| 設定ファイル  | `config/**/*.js`                |
+| テスト     | `test/**/*.js`                  |
+| その他     | 明示的に指定したファイルまたはフォルダ           |
+
+---
+
+## Web情報取得・検索のポリシー
+
+AIツールが外部情報を取得する際は、原則として以下の信頼性の高い公式ドキュメントを優先します：
+
+* 公式パッケージレジストリやドキュメント（例：MDN、npmなど）
+* 使用するフレームワークやサービスの公式ドキュメント
+* 言語・ライブラリの公式リファレンス
+
+> 他サイトの情報取得はプロンプト内で指示された場合に限定します。
+
+---
+
+## AIツールへの前提条件
+
+AIツールは以下の前提に基づいて動作します：
+
+* 回答は常に **日本語＋Markdown形式**
+* 不明点がある場合は **推定・補完・設計提案** を含めて出力
+* システム間の**整合性を最重視**
+* 明示的に関与しないと指定された処理には関与しない
+* 許可されていないコマンドを**直接実行しない**
+
+---
+
+## AIツールを使用する前の確認事項
+
+* AIツール用の設定ファイル（例：`.ai-tool/settings.json`）で必要な権限が許可されていることを確認
+* AIツール用のターゲットがMakefileやスクリプトに存在することを確認
+* AIツールの出力はあくまで補助的であり、最終的な仕様やコードのレビュー・確認は開発者が必ず行う
+
+---
+
+## Project Structure
+- `pages/`: HTMLページファイル
+- `scripts/`: ページ固有のJavaScriptファイル
+- `styles/`: CSSスタイルファイル
+- `src/`: アプリケーションのコアロジック
+  - `components/`: 再利用可能なコンポーネント
+  - `models/`: データモデル定義
+  - `services/`: API、認証、通知等のサービス層
+  - `utils/`: ユーティリティ関数
+- `data/`: JSONデータファイル
+- `assets/`: 静的リソース（画像、フォント等）
+- `config/`: 設定ファイル
+
+## Important Notes
+- Main branch: `main`
+- Pure HTML/CSS/JavaScript project (no build process required)
+- Follow existing code conventions and patterns
+- Always test changes manually before committing
+
+---
+
+このドキュメントは、AI支援ツールがプロジェクトにおいて安全・確実かつ構造化された支援を提供するための共通ガイドラインです。

--- a/pages/coupon-list.html
+++ b/pages/coupon-list.html
@@ -26,7 +26,6 @@
         <header class="flex justify-between items-center mb-6 animate-on-load" style="animation-delay: 100ms;">
           <div class="back-button flex items-center text-gray-700 cursor-pointer clickable-button" data-action="navigate" data-url="index.html">
             <i data-lucide="arrow-left" class="mr-2"></i>
-            <span class="font-medium">ホーム</span>
           </div>
           <h1 class="text-xl font-bold text-gray-800">クーポン一覧</h1>
           <i data-lucide="search" class="text-gray-700 cursor-pointer"></i>

--- a/pages/event-calendar.html
+++ b/pages/event-calendar.html
@@ -27,7 +27,6 @@
         <header class="flex justify-between items-center mb-6 animate-on-load" style="animation-delay: 100ms;">
           <div class="back-button flex items-center text-gray-700 cursor-pointer clickable-button" data-action="navigate" data-url="index.html">
             <i data-lucide="arrow-left" class="mr-2"></i>
-            <span class="font-medium">ホーム</span>
           </div>
           <h1 class="text-xl font-bold text-gray-800">イベントカレンダー</h1>
           <button class="text-gray-700 hover:text-gray-900 clickable-button" data-action="navigate" data-url="notification-settings.html">

--- a/pages/experience-share.html
+++ b/pages/experience-share.html
@@ -26,7 +26,6 @@
         <header class="flex justify-between items-center mb-6 animate-on-load" style="animation-delay: 100ms;">
           <div class="back-button flex items-center text-gray-700 cursor-pointer clickable-button" data-action="navigate" data-url="index.html">
             <i data-lucide="arrow-left" class="mr-2"></i>
-            <span class="font-medium">ホーム</span>
           </div>
           <h1 class="text-xl font-bold text-gray-800">体験をシェア</h1>
           <i data-lucide="settings" class="text-gray-700 cursor-pointer clickable-button"></i>

--- a/pages/saved-spot-list.html
+++ b/pages/saved-spot-list.html
@@ -26,7 +26,6 @@
         <header class="flex justify-between items-center mb-6 animate-on-load" style="animation-delay: 100ms;">
           <div class="back-button flex items-center text-gray-700 cursor-pointer clickable-button" data-action="navigate" data-url="index.html">
             <i data-lucide="arrow-left" class="mr-2"></i>
-            <span class="font-medium">ホーム</span>
           </div>
           <h1 class="text-xl font-bold text-gray-800">保存済みスポット</h1>
           <i data-lucide="search" class="text-gray-700 cursor-pointer"></i>

--- a/pages/spot-reservation.html
+++ b/pages/spot-reservation.html
@@ -26,7 +26,6 @@
         <header class="flex justify-between items-center mb-6 animate-on-load" style="animation-delay: 100ms;">
           <div class="back-button flex items-center text-gray-700 cursor-pointer clickable-button" data-action="navigate" data-url="index.html">
             <i data-lucide="arrow-left" class="mr-2"></i>
-            <span class="font-medium">ホーム</span>
           </div>
           <h1 class="text-xl font-bold text-gray-800">スポット予約</h1>
           <div class="w-6"></div> <!-- スペーサー -->

--- a/pages/user-profile.html
+++ b/pages/user-profile.html
@@ -26,7 +26,6 @@
         <header class="flex justify-between items-center mb-6 animate-on-load" style="animation-delay: 100ms;">
           <div class="back-button flex items-center text-gray-700 cursor-pointer clickable-button" data-action="navigate" data-url="index.html">
             <i data-lucide="arrow-left" class="mr-2"></i>
-            <span class="font-medium">ホーム</span>
           </div>
           <h1 class="text-xl font-bold text-gray-800">マイページ</h1>
           <i data-lucide="settings" class="text-gray-700 cursor-pointer clickable-button" data-action="navigate" data-url="settings.html"></i>

--- a/scripts/saved-spot.js
+++ b/scripts/saved-spot.js
@@ -90,7 +90,8 @@ function renderSpotList(data) {
                     class="text-xs bg-emerald-400/80 text-white px-3 py-1 rounded-full hover:bg-emerald-500 transition-colors">
               詳細
             </button>
-            <button class="text-xs bg-blue-400/80 text-white px-3 py-1 rounded-full hover:bg-blue-500 transition-colors">
+            <button onclick="reserveSpot(${spot.id})" 
+                    class="text-xs bg-blue-400/80 text-white px-3 py-1 rounded-full hover:bg-blue-500 transition-colors">
               予約
             </button>
           </div>
@@ -131,5 +132,20 @@ function toggleFavorite(id) {
     if (currentCategory === "favorite") {
       renderSpotList(spotsData);
     }
+  }
+}
+
+// スポット予約機能
+function reserveSpot(spotId) {
+  const spot = spotsData.find(s => s.id === spotId);
+  if (spot) {
+    // URLパラメータでスポット情報を渡して予約ページに遷移
+    const params = new URLSearchParams({
+      spotId: spot.id,
+      spotName: spot.name,
+      category: spot.category || '',
+      rating: spot.rating || ''
+    });
+    location.href = `spot-reservation.html?${params.toString()}`;
   }
 }

--- a/scripts/spot-reservation.js
+++ b/scripts/spot-reservation.js
@@ -6,7 +6,31 @@ let reservationData = {};
 
 // 初期化
 onDOMReady(() => {
-    showPage('home');
+    // URLパラメータから情報を取得
+    const urlParams = new URLSearchParams(window.location.search);
+    const spotId = urlParams.get('spotId');
+    const spotName = urlParams.get('spotName');
+    const category = urlParams.get('category');
+    const rating = urlParams.get('rating');
+    
+    // URLパラメータからスポット情報が渡された場合
+    if (spotId && spotName) {
+        selectedSpot = {
+            id: spotId,
+            name: spotName,
+            category: category || '',
+            rating: rating || '',
+            description: `${category}として人気のスポット`,
+            fee: '要確認',
+            hours: '要確認'
+        };
+        
+        // 直接詳細ページに移動
+        showPage('detail');
+    } else {
+        showPage('home');
+    }
+    
     initializeEventListeners();
 });
 


### PR DESCRIPTION
  - 保存済みスポット一覧の予約ボタンに遷移機能を実装
  - URLパラメータでスポット情報を予約ページに渡す仕組みを追加
  - 予約ページでURLパラメータを受け取り自動的にスポット情報を表示
  - 各ページのヘッダーから「ホーム」テキストを削除してシンプルなUIに改善